### PR TITLE
fix(version): jira updated to `9.4.11` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Role Variables
   - `software` (default)
   - `core`
 
-- `jira_version` The specific version of Jira to download (default: `8.20.2`).
-- `jira_archive_name` Jira archive name (default: `atlassian-jira-software-8.20.2.tar.gz`).
+- `jira_version` The specific version of Jira to download (default: `9.4.11`).
+- `jira_archive_name` Jira archive name (default: `atlassian-jira-software-9.4.11.tar.gz`).
 - `jira_download_url` URL to download an archive with Jira (default: `https://www.atlassian.com/software/jira/downloads/binary`).
 - `jira_username` and `jira_group` Unix username and group (default: `jira`).
 - `jira_root_path` Path to Jira installation directory (default: `/opt/atlassian/jira`).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 jira_product: 'software'
-jira_version: '8.20.2'
+jira_version: '9.4.11'
 jira_archive_name: 'atlassian-jira-{{ jira_product }}-{{ jira_version }}.tar.gz'
 jira_download_url: 'https://www.atlassian.com/software/jira/downloads/binary'
 

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -109,7 +109,7 @@
 
             </Host>
             <Valve className="org.apache.catalina.valves.AccessLogValve"
-                   pattern="%a %{jira.request.id}r %{jira.request.username}r %t &quot;%m %U%q %H&quot; %s %b %D &quot;%{Referer}i&quot; &quot;%{User-Agent}i&quot; &quot;%{jira.request.assession.id}r&quot;"/>
+                   pattern="%a %{jira.request.id}r %{jira.request.username}r %t &quot;%m %U%{sanitized.query}r %H&quot; %s %b %D &quot;%{sanitized.referer}r&quot; &quot;%{User-Agent}i&quot; &quot;%{jira.request.assession.id}r&quot;"/>
         </Engine>
     </Service>
 </Server>


### PR DESCRIPTION
Atlassian released a new LTS version of [Jira](https://confluence.atlassian.com/display/JIRASOFTWARE/JIRA+Software+9.4.x+release+notes) - **9.4.11**!

This automated PR updates code to bring new version into repository.