### PR TITLE
fix(version): jira updated to `9.12.0` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Role Variables
   - `software` (default)
   - `core`
 
-- `jira_version` The specific version of Jira to download (default: `9.4.12`).
-- `jira_archive_name` Jira archive name (default: `atlassian-jira-software-9.4.12.tar.gz`).
+- `jira_version` The specific version of Jira to download (default: `9.12.0`).
+- `jira_archive_name` Jira archive name (default: `atlassian-jira-software-9.12.0.tar.gz`).
 - `jira_download_url` URL to download an archive with Jira (default: `https://www.atlassian.com/software/jira/downloads/binary`).
 - `jira_username` and `jira_group` Unix username and group (default: `jira`).
 - `jira_root_path` Path to Jira installation directory (default: `/opt/atlassian/jira`).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,6 @@ jira_jvm_minimum_memory: '384m'
 jira_jvm_maximum_memory: '2048m'
 jira_jvm_initial_code_cache_size: '32m'
 jira_jvm_reserved_code_cache_size: '512m'
-jira_jvm_required_args: '-Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true -Dorg.dom4j.factory=com.atlassian.core.xml.InterningDocumentFactory'
 
 # Jira database connection settings.
 jira_db_configuration: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 jira_product: 'software'
-jira_version: '9.4.12'
+jira_version: '9.12.0'
 jira_archive_name: 'atlassian-jira-{{ jira_product }}-{{ jira_version }}.tar.gz'
 jira_download_url: 'https://www.atlassian.com/software/jira/downloads/binary'
 

--- a/templates/setenv.sh.j2
+++ b/templates/setenv.sh.j2
@@ -35,7 +35,7 @@ JVM_CODE_CACHE_ARGS='-XX:InitialCodeCacheSize={{ jira_jvm_initial_code_cache_siz
 #
 # The following are the required arguments for Jira.
 #
-JVM_REQUIRED_ARGS='{{ jira_jvm_required_args }}'
+JVM_REQUIRED_ARGS='-Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector -Dlog4j2.disableJmx=true -Dlog4j2.garbagefree.threadContextMap=true -Dlog4j2.isWebapp=false -Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true -Dorg.dom4j.factory=com.atlassian.core.xml.InterningDocumentFactory'
 
 # Uncomment this setting if you want to import data without notifications
 #
@@ -65,24 +65,32 @@ JIRA_HOME_MINUSD=""
 if [ "$JIRA_HOME" != "" ]; then
     echo $JIRA_HOME | grep -q " "
     if [ $? -eq 0 ]; then
-	    echo ""
-	    echo "--------------------------------------------------------------------------------------------------------------------"
-		echo "   WARNING : You cannot have a JIRA_HOME environment variable set with spaces in it. This variable is being ignored"
-	    echo "--------------------------------------------------------------------------------------------------------------------"
+      echo ""
+      echo "--------------------------------------------------------------------------------------------------------------------"
+      echo "  WARNING : You cannot have a JIRA_HOME environment variable set with spaces in it. This variable is being ignored  "
+      echo "--------------------------------------------------------------------------------------------------------------------"
     else
-		JIRA_HOME_MINUSD=-Djira.home=$JIRA_HOME
+    JIRA_HOME_MINUSD=-Djira.home=$JIRA_HOME
     fi
 fi
-
-JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JVM_CODE_CACHE_ARGS} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMENDED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD} ${START_JIRA_JAVA_OPTS}"
-
-export JAVA_OPTS
 
 # DO NOT remove the following line
 # !INSTALLER SET JAVA_HOME
 
+JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JVM_CODE_CACHE_ARGS} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMENDED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD} ${START_JIRA_JAVA_OPTS}"
+
+j_ver=`echo "$($JAVA_HOME/bin/java -version 2>&1)" | grep "version" | awk '{ print substr($3, 2, length($3)-2); }'`
+IFS='.' read -a j_ver_parts <<< "$j_ver"
+
+if [[ ${j_ver_parts[0]} = 17 ]]; then
+  JVM_OPENS=$(cat $PRGDIR/java-opens.txt)
+  JAVA_OPTS="$JVM_OPENS $JAVA_OPTS"
+fi
+
+export JAVA_OPTS
+
 echo ""
-echo "If you encounter issues starting or stopping Jira, please see the Troubleshooting guide at https://docs.atlassian.com/jira/jadm-docs-0813/Troubleshooting+installation"
+echo "If you encounter issues starting or stopping Jira, please see the Troubleshooting guide at https://docs.atlassian.com/jira/jadm-docs-0912/Troubleshooting+installation"
 echo ""
 if [ "$JIRA_HOME_MINUSD" != "" ]; then
     echo "Using JIRA_HOME:       $JIRA_HOME"


### PR DESCRIPTION
Atlassian released a new LTS version of [Jira](https://confluence.atlassian.com/display/JIRASOFTWARE/JIRA+Software+9.12.x+release+notes) - **9.12.0**!

This automated PR updates code to bring new version into repository.