### PR TITLE
fix(version): jira updated to `null` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Role Variables
   - `software` (default)
   - `core`
 
-- `jira_version` The specific version of Jira to download (default: `9.12.0`).
-- `jira_archive_name` Jira archive name (default: `atlassian-jira-software-9.12.0.tar.gz`).
+- `jira_version` The specific version of Jira to download (default: `null`).
+- `jira_archive_name` Jira archive name (default: `atlassian-jira-software-null.tar.gz`).
 - `jira_download_url` URL to download an archive with Jira (default: `https://www.atlassian.com/software/jira/downloads/binary`).
 - `jira_username` and `jira_group` Unix username and group (default: `jira`).
 - `jira_root_path` Path to Jira installation directory (default: `/opt/atlassian/jira`).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 jira_product: 'software'
-jira_version: '9.12.0'
+jira_version: 'null'
 jira_archive_name: 'atlassian-jira-{{ jira_product }}-{{ jira_version }}.tar.gz'
 jira_download_url: 'https://www.atlassian.com/software/jira/downloads/binary'
 


### PR DESCRIPTION
Atlassian released a new LTS version of [Jira](null) - **null**!

This automated PR updates code to bring new version into repository.