### PR TITLE
fix(version): jira updated to `10.3.7` release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 jira_product: 'software'
-jira_version: '10.3.6'
+jira_version: '10.3.7'
 jira_archive_name: 'atlassian-jira-{{ jira_product }}-{{ jira_version }}.tar.gz'
 jira_download_url: 'https://www.atlassian.com/software/jira/downloads/binary'
 jira_checksum_url: '{{ jira_download_url }}/{{ jira_archive_name }}.sha256'

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -16,7 +16,7 @@ argument_specs:
       jira_version:
         type: 'str'
         description: 'The version of Jira to download.'
-        default: '10.3.6'
+        default: '10.3.7'
       jira_archive_name:
         type: 'str'
         description: 'Jira archive name.'


### PR DESCRIPTION
Atlassian released a new LTS version of [Jira](https://confluence.atlassian.com/display/JIRASOFTWARE/JIRA+Software+10.3.x+release+notes) - **10.3.7**!

This automated PR updates code to bring new version into repository.